### PR TITLE
Add map data loader

### DIFF
--- a/pages/api/map.js
+++ b/pages/api/map.js
@@ -1,0 +1,31 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    const response = await fetch('https://ts5.x1.asia.travian.com/map.sql')
+    const sql = await response.text()
+    const villages = parseMapSql(sql)
+    res.status(200).json({ villages })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'Failed to load map data' })
+  }
+}
+
+function parseMapSql(sql) {
+  const lines = sql.split('\n')
+  const villages = []
+  const regex = /INSERT INTO `x_world` VALUES \(\d+,(-?\d+),(-?\d+),\d+,\d+,'([^']*)',\d+,'([^']*)',\d+,'([^']*)'/
+  for (const line of lines) {
+    const m = regex.exec(line)
+    if (m) {
+      villages.push({
+        x: Number(m[1]),
+        y: Number(m[2]),
+        village: m[3],
+        player: m[4],
+        alliance: m[5] === 'NULL' ? '' : m[5],
+      })
+    }
+  }
+  return villages
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 
 const troopSpeeds = {
   Teuton: [
@@ -57,7 +57,18 @@ function formatTime(hours) {
   return `${h}h ${m}m`
 }
 
+function extractCoords(text) {
+  if (!text) return null
+  const m = text.match(/-?\d+\s*[|,/]\s*-?\d+/)
+  if (!m) return null
+  const [x, y] = m[0].split(/[|,/]/).map(v => parseInt(v.trim(), 10))
+  return { x, y }
+}
+
 export default function Home() {
+  const [tab, setTab] = useState('report')
+  const [mapData, setMapData] = useState([])
+  const [loadingMap, setLoadingMap] = useState(false)
   const [form, setForm] = useState({
     defender: '',
     attacker: '',
@@ -67,6 +78,29 @@ export default function Home() {
     reporter: '',
   })
   const [result, setResult] = useState(null)
+
+  const loadMapData = async () => {
+    setLoadingMap(true)
+    try {
+      const res = await fetch('/api/map')
+      const data = await res.json()
+      if (res.ok) {
+        setMapData(data.villages)
+      } else {
+        alert(data.error || 'Failed to load map data')
+      }
+    } catch (e) {
+      alert('Failed to load map data')
+    } finally {
+      setLoadingMap(false)
+    }
+  }
+
+  const attackerVillage = useMemo(() => {
+    const c = extractCoords(form.attacker)
+    if (!c) return null
+    return mapData.find(v => v.x === c.x && v.y === c.y) || null
+  }, [form.attacker, mapData])
 
   const handleChange = e => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -89,29 +123,76 @@ export default function Home() {
 
   return (
     <div className="max-w-xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Travian Defense Reporter</h1>
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <input name="defender" placeholder="Defender coords 123|456" className="border p-2 w-full" value={form.defender} onChange={handleChange} required />
-        <input name="attacker" placeholder="Attacker coords 234|567" className="border p-2 w-full" value={form.attacker} onChange={handleChange} required />
-        <input type="datetime-local" name="landing" className="border p-2 w-full" value={form.landing} onChange={handleChange} required />
-        <input type="datetime-local" name="firstSeen" className="border p-2 w-full" value={form.firstSeen} onChange={handleChange} required />
-        <select name="tribe" className="border p-2 w-full" value={form.tribe} onChange={handleChange}>
-          <option>Teuton</option>
-          <option>Roman</option>
-          <option>Gaul</option>
-        </select>
-        <input name="reporter" placeholder="Reporter name (optional)" className="border p-2 w-full" value={form.reporter} onChange={handleChange} />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2">Submit</button>
-      </form>
-      {result && (
-        <div className="mt-4 border p-2">
-          <h2 className="font-bold">Report Saved</h2>
-          <p>Distance: {result.distance.toFixed(2)}</p>
-          <ul className="list-disc ml-4">
-            {result.times.map(t => (
-              <li key={t.name}>{t.name}: {t.time}</li>
-            ))}
-          </ul>
+      <div className="flex justify-between items-center mb-4">
+        <div>
+          <button className={tab === 'report' ? 'font-bold mr-2' : 'mr-2'} onClick={() => setTab('report')}>Report</button>
+          <button className={tab === 'map' ? 'font-bold' : ''} onClick={() => setTab('map')}>Map Data</button>
+        </div>
+        <button onClick={loadMapData} className="bg-green-500 text-white px-3 py-1">
+          {loadingMap ? 'Loading...' : 'Load Map Data'}
+        </button>
+      </div>
+
+      {tab === 'report' && (
+        <>
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <input name="defender" placeholder="Defender coords 123|456" className="border p-2 w-full" value={form.defender} onChange={handleChange} required />
+            <input name="attacker" placeholder="Attacker coords 234|567" className="border p-2 w-full" value={form.attacker} onChange={handleChange} required />
+            {attackerVillage && (
+              <p className="text-sm">Village: {attackerVillage.village} ({attackerVillage.player})</p>
+            )}
+            <input type="datetime-local" name="landing" className="border p-2 w-full" value={form.landing} onChange={handleChange} required />
+            <input type="datetime-local" name="firstSeen" className="border p-2 w-full" value={form.firstSeen} onChange={handleChange} required />
+            <select name="tribe" className="border p-2 w-full" value={form.tribe} onChange={handleChange}>
+              <option>Teuton</option>
+              <option>Roman</option>
+              <option>Gaul</option>
+            </select>
+            <input name="reporter" placeholder="Reporter name (optional)" className="border p-2 w-full" value={form.reporter} onChange={handleChange} />
+            <button type="submit" className="bg-blue-500 text-white px-4 py-2">Submit</button>
+          </form>
+          {result && (
+            <div className="mt-4 border p-2">
+              <h2 className="font-bold">Report Saved</h2>
+              <p>Distance: {result.distance.toFixed(2)}</p>
+              <ul className="list-disc ml-4">
+                {result.times.map(t => (
+                  <li key={t.name}>{t.name}: {t.time}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+
+      {tab === 'map' && (
+        <div>
+          <p className="mb-2">Total villages: {mapData.length}</p>
+          <button onClick={loadMapData} className="bg-green-500 text-white px-3 py-1 mb-2">
+            {loadingMap ? 'Loading...' : 'Refresh'}
+          </button>
+          <div className="max-h-80 overflow-y-scroll border text-sm">
+            <table className="min-w-full border-collapse">
+              <thead>
+                <tr>
+                  <th className="border px-2">Village</th>
+                  <th className="border px-2">Player</th>
+                  <th className="border px-2">Alliance</th>
+                  <th className="border px-2">Coords</th>
+                </tr>
+              </thead>
+              <tbody>
+                {mapData.slice(0, 100).map((v, i) => (
+                  <tr key={i}>
+                    <td className="border px-2">{v.village}</td>
+                    <td className="border px-2">{v.player}</td>
+                    <td className="border px-2">{v.alliance}</td>
+                    <td className="border px-2">{v.x}|{v.y}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- support loading Travian map SQL via `/api/map`
- parse player/village/alliance data and show it on a new Map Data tab
- look up attacker coordinates and show the village name automatically

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687faa9c8fd0832fa115724237933a1d