### PR TITLE
Add map data loading and village lookup

### DIFF
--- a/pages/api/map.js
+++ b/pages/api/map.js
@@ -1,0 +1,26 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    const response = await fetch('https://ts5.x1.asia.travian.com/map.sql')
+    if (!response.ok) throw new Error('download failed')
+    const text = await response.text()
+    const villages = []
+    text.split('\n').forEach(line => {
+      if (!line.startsWith('INSERT INTO')) return
+      const m = line.match(/\((.*)\)/)
+      if (!m) return
+      const vals = m[1].match(/('[^']*'|NULL|[^,]+)/g)
+      if (!vals || vals.length < 10) return
+      const x = Number(vals[1])
+      const y = Number(vals[2])
+      const villageName = vals[5].replace(/^'(.*)'$/, '$1')
+      const playerName = vals[7].replace(/^'(.*)'$/, '$1')
+      const alliance = vals[9].replace(/^'(.*)'$/, '$1')
+      villages.push({ x, y, villageName, playerName, alliance })
+    })
+    res.status(200).json({ villages })
+  } catch (e) {
+    console.error(e)
+    res.status(500).json({ error: 'Failed to load map data' })
+  }
+}

--- a/pages/api/report.js
+++ b/pages/api/report.js
@@ -31,8 +31,9 @@ export default async function handler(req, res) {
 }
 
 function parseCoords(coords) {
-  const [x, y] = coords.split('|').map(Number)
-  return { x, y }
+  const m = coords.match(/(-?\d+)\s*[|,\/]\s*(-?\d+)/)
+  if (!m) throw new Error('Invalid coords')
+  return { x: Number(m[1]), y: Number(m[2]) }
 }
 
 function travianDistance(d1, d2) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -39,9 +39,10 @@ const troopSpeeds = {
   ],
 }
 
-function parseCoords(coords) {
-  const [x, y] = coords.split('|').map(Number)
-  return { x, y }
+function parseCoordsInput(input) {
+  const match = input.match(/(-?\d+)\s*[|,\/]\s*(-?\d+)/)
+  if (!match) return null
+  return { x: Number(match[1]), y: Number(match[2]) }
 }
 
 function travianDistance(d1, d2) {
@@ -58,6 +59,7 @@ function formatTime(hours) {
 }
 
 export default function Home() {
+  const [activeTab, setActiveTab] = useState('report')
   const [form, setForm] = useState({
     defender: '',
     attacker: '',
@@ -67,9 +69,36 @@ export default function Home() {
     reporter: '',
   })
   const [result, setResult] = useState(null)
+  const [mapData, setMapData] = useState([])
+  const [loadingMap, setLoadingMap] = useState(false)
+  const [attackerVillage, setAttackerVillage] = useState('')
+  const [defenderVillage, setDefenderVillage] = useState('')
 
   const handleChange = e => {
     setForm({ ...form, [e.target.name]: e.target.value })
+    if (mapData.length && (e.target.name === 'attacker' || e.target.name === 'defender')) {
+      const coords = parseCoordsInput(e.target.value)
+      const village = coords ? mapData.find(v => v.x === coords.x && v.y === coords.y) : null
+      if (e.target.name === 'attacker') setAttackerVillage(village ? village.villageName : '')
+      if (e.target.name === 'defender') setDefenderVillage(village ? village.villageName : '')
+    }
+  }
+
+  const loadMapData = async () => {
+    setLoadingMap(true)
+    try {
+      const res = await fetch('/api/map')
+      const data = await res.json()
+      if (res.ok) {
+        setMapData(data.villages)
+      } else {
+        alert(data.error || 'Failed to load map data')
+      }
+    } catch (e) {
+      alert('Failed to load map data')
+    } finally {
+      setLoadingMap(false)
+    }
   }
 
   const handleSubmit = async e => {
@@ -89,29 +118,74 @@ export default function Home() {
 
   return (
     <div className="max-w-xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Travian Defense Reporter</h1>
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <input name="defender" placeholder="Defender coords 123|456" className="border p-2 w-full" value={form.defender} onChange={handleChange} required />
-        <input name="attacker" placeholder="Attacker coords 234|567" className="border p-2 w-full" value={form.attacker} onChange={handleChange} required />
-        <input type="datetime-local" name="landing" className="border p-2 w-full" value={form.landing} onChange={handleChange} required />
-        <input type="datetime-local" name="firstSeen" className="border p-2 w-full" value={form.firstSeen} onChange={handleChange} required />
-        <select name="tribe" className="border p-2 w-full" value={form.tribe} onChange={handleChange}>
-          <option>Teuton</option>
-          <option>Roman</option>
-          <option>Gaul</option>
-        </select>
-        <input name="reporter" placeholder="Reporter name (optional)" className="border p-2 w-full" value={form.reporter} onChange={handleChange} />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2">Submit</button>
-      </form>
-      {result && (
-        <div className="mt-4 border p-2">
-          <h2 className="font-bold">Report Saved</h2>
-          <p>Distance: {result.distance.toFixed(2)}</p>
-          <ul className="list-disc ml-4">
-            {result.times.map(t => (
-              <li key={t.name}>{t.name}: {t.time}</li>
-            ))}
-          </ul>
+      <div className="flex justify-between items-center mb-4">
+        <div className="space-x-2">
+          <button onClick={() => setActiveTab('report')} className={activeTab === 'report' ? 'font-bold' : ''}>Report</button>
+          <button onClick={() => setActiveTab('map')} className={activeTab === 'map' ? 'font-bold' : ''}>Map Data</button>
+        </div>
+        <button onClick={loadMapData} className="bg-green-500 text-white px-2 py-1">
+          {loadingMap ? 'Loading...' : 'Load Map Data'}
+        </button>
+      </div>
+      {activeTab === 'report' && (
+        <>
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <div>
+              <input name="defender" placeholder="Defender coords 123|456" className="border p-2 w-full" value={form.defender} onChange={handleChange} required />
+              {defenderVillage && <p className="text-sm text-gray-600">{defenderVillage}</p>}
+            </div>
+            <div>
+              <input name="attacker" placeholder="Attacker coords 234|567" className="border p-2 w-full" value={form.attacker} onChange={handleChange} required />
+              {attackerVillage && <p className="text-sm text-gray-600">{attackerVillage}</p>}
+            </div>
+            <input type="datetime-local" name="landing" className="border p-2 w-full" value={form.landing} onChange={handleChange} required />
+            <input type="datetime-local" name="firstSeen" className="border p-2 w-full" value={form.firstSeen} onChange={handleChange} required />
+            <select name="tribe" className="border p-2 w-full" value={form.tribe} onChange={handleChange}>
+              <option>Teuton</option>
+              <option>Roman</option>
+              <option>Gaul</option>
+            </select>
+            <input name="reporter" placeholder="Reporter name (optional)" className="border p-2 w-full" value={form.reporter} onChange={handleChange} />
+            <button type="submit" className="bg-blue-500 text-white px-4 py-2">Submit</button>
+          </form>
+          {result && (
+            <div className="mt-4 border p-2">
+              <h2 className="font-bold">Report Saved</h2>
+              <p>Distance: {result.distance.toFixed(2)}</p>
+              <ul className="list-disc ml-4">
+                {result.times.map(t => (
+                  <li key={t.name}>{t.name}: {t.time}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+      {activeTab === 'map' && (
+        <div>
+          <p className="mb-2">Villages loaded: {mapData.length}</p>
+          <div className="overflow-auto max-h-96 border">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1 border">Village</th>
+                  <th className="px-2 py-1 border">Player</th>
+                  <th className="px-2 py-1 border">Alliance</th>
+                  <th className="px-2 py-1 border">Coords</th>
+                </tr>
+              </thead>
+              <tbody>
+                {mapData.map((v, idx) => (
+                  <tr key={idx}>
+                    <td className="border px-2 py-1">{v.villageName}</td>
+                    <td className="border px-2 py-1">{v.playerName}</td>
+                    <td className="border px-2 py-1">{v.alliance}</td>
+                    <td className="border px-2 py-1">({v.x}|{v.y})</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add new API route to download and parse Travian map.sql
- show Load Map Data button with basic tabs
- auto-detect village names from loaded map data
- update coordinates parser to accept multiple delimiters

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687faa9c8fd0832fa115724237933a1d