### PR TITLE
Add attack reports tab with defense finder

### DIFF
--- a/pages/api/report.js
+++ b/pages/api/report.js
@@ -2,6 +2,10 @@ import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
+function parseBangkokDate(str) {
+  return new Date(`${str}+07:00`)
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
   const { defender, attacker, landing, firstSeen, tribe, reporter } = req.body
@@ -13,8 +17,8 @@ export default async function handler(req, res) {
       data: {
         defenderCoords: defender,
         attackerCoords: attacker,
-        landingTime: new Date(landing),
-        firstSeenTime: new Date(firstSeen),
+        landingTime: parseBangkokDate(landing),
+        firstSeenTime: parseBangkokDate(firstSeen),
         tribe,
         reporter,
       },

--- a/pages/api/reports.js
+++ b/pages/api/reports.js
@@ -1,0 +1,14 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    const reports = await prisma.attackReport.findMany({ orderBy: { id: 'desc' } })
+    res.status(200).json({ reports })
+  } catch (e) {
+    console.error(e)
+    res.status(500).json({ error: 'Failed to load reports' })
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 const troopSpeeds = {
   Teuton: [
@@ -58,6 +58,43 @@ function formatTime(hours) {
   return `${h}h ${m}m`
 }
 
+
+function parseBangkokDate(str) {
+  // treat the given local datetime string as being in the Asia/Bangkok timezone
+  return new Date(`${str}+07:00`)
+}
+
+function gatherEligibleVillages(mapData, defenderCoords, landing) {
+  const defVillage = mapData.find(v => v.x === defenderCoords.x && v.y === defenderCoords.y)
+  if (!defVillage) return { alliance: '', villages: [] }
+  const alliance = defVillage.alliance
+  const selectedUnits = ['Spearman', 'Paladin', 'Praetorian', 'Equites Caesaris', 'Phalanx', 'Druidrider']
+  const speedLookup = {}
+  Object.values(troopSpeeds).flat().forEach(t => {
+    speedLookup[t.name] = t.speed
+  })
+  // use current time in Thailand regardless of the user's timezone
+  const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Bangkok' }))
+  const landingTime = landing instanceof Date ? landing : parseBangkokDate(landing)
+  const villages = []
+  mapData.forEach(v => {
+    if (v.alliance !== alliance) return
+    const dist = travianDistance(defenderCoords, { x: v.x, y: v.y })
+    let best = null
+    selectedUnits.forEach(u => {
+      const hours = dist / speedLookup[u]
+      const arrive = now.getTime() + hours * 3600 * 1000
+      if (arrive <= landingTime.getTime()) {
+        if (!best || hours < best.hours) best = { unit: u, hours }
+      }
+    })
+    if (best) {
+      villages.push({ ...v, unit: best.unit, time: formatTime(best.hours) })
+    }
+  })
+  return { alliance, villages }
+}
+
 export default function Home() {
   const [activeTab, setActiveTab] = useState('report')
   const [form, setForm] = useState({
@@ -68,11 +105,18 @@ export default function Home() {
     tribe: 'Teuton',
     reporter: '',
   })
-  const [result, setResult] = useState(null)
+  const [reports, setReports] = useState([])
   const [mapData, setMapData] = useState([])
   const [loadingMap, setLoadingMap] = useState(false)
   const [attackerVillage, setAttackerVillage] = useState('')
   const [defenderVillage, setDefenderVillage] = useState('')
+  const [defenseResults, setDefenseResults] = useState({})
+
+  useEffect(() => {
+    if (activeTab === 'reports' && reports.length === 0) {
+      loadReports()
+    }
+  }, [activeTab])
 
   const handleChange = e => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -80,7 +124,9 @@ export default function Home() {
       const coords = parseCoordsInput(e.target.value)
       const village = coords ? mapData.find(v => v.x === coords.x && v.y === coords.y) : null
       if (e.target.name === 'attacker') setAttackerVillage(village ? village.villageName : '')
-      if (e.target.name === 'defender') setDefenderVillage(village ? village.villageName : '')
+      if (e.target.name === 'defender') {
+        setDefenderVillage(village ? village.villageName : '')
+      }
     }
   }
 
@@ -101,8 +147,57 @@ export default function Home() {
     }
   }
 
+  const loadReports = async () => {
+    try {
+      const res = await fetch('/api/reports')
+      const data = await res.json()
+      if (res.ok) {
+        const processed = data.reports.map(r => {
+          const d1 = parseCoordsInput(r.defenderCoords)
+          const d2 = parseCoordsInput(r.attackerCoords)
+          const distance = travianDistance(d1, d2)
+          const times = troopSpeeds[r.tribe].map(t => ({ name: t.name, time: formatTime(distance / t.speed) }))
+          return {
+            id: r.id,
+            defender: r.defenderCoords,
+            attacker: r.attackerCoords,
+            landing: r.landingTime,
+            firstSeen: r.firstSeenTime,
+            tribe: r.tribe,
+            reporter: r.reporter || '',
+            distance,
+            times,
+          }
+        })
+        setReports(processed)
+      } else {
+        alert(data.error || 'Failed to load reports')
+      }
+    } catch (e) {
+      alert('Failed to load reports')
+    }
+  }
+
   const handleSubmit = async e => {
     e.preventDefault()
+    let currentMap = mapData
+    if (!currentMap.length) {
+      setLoadingMap(true)
+      try {
+        const mres = await fetch('/api/map')
+        const mdata = await mres.json()
+        if (mres.ok) {
+          setMapData(mdata.villages)
+          currentMap = mdata.villages
+        } else {
+          alert(mdata.error || 'Failed to load map data')
+        }
+      } catch (err) {
+        alert('Failed to load map data')
+      } finally {
+        setLoadingMap(false)
+      }
+    }
     const res = await fetch('/api/report', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -110,10 +205,45 @@ export default function Home() {
     })
     const data = await res.json()
     if (res.ok) {
-      setResult(data)
+      const newReport = {
+        id: data.id,
+        ...form,
+        distance: data.distance,
+        times: data.times,
+      }
+      setReports(r => [newReport, ...r])
+      setActiveTab('reports')
     } else {
       alert(data.error || 'Error')
     }
+  }
+
+  const handleFindDefense = async report => {
+    let currentMap = mapData
+    if (!currentMap.length) {
+      setLoadingMap(true)
+      try {
+        const mres = await fetch('/api/map')
+        const mdata = await mres.json()
+        if (mres.ok) {
+          setMapData(mdata.villages)
+          currentMap = mdata.villages
+        } else {
+          alert(mdata.error || 'Failed to load map data')
+          return
+        }
+      } catch (err) {
+        alert('Failed to load map data')
+        return
+      } finally {
+        setLoadingMap(false)
+      }
+    }
+    const coords = parseCoordsInput(report.defender)
+    if (!coords) return
+    const landingVal = typeof report.landing === 'string' && report.landing.includes('Z') ? new Date(report.landing) : report.landing
+    const { alliance, villages } = gatherEligibleVillages(currentMap, coords, landingVal)
+    setDefenseResults(r => ({ ...r, [report.id]: { alliance, villages } }))
   }
 
   return (
@@ -122,6 +252,7 @@ export default function Home() {
         <div className="space-x-2">
           <button onClick={() => setActiveTab('report')} className={activeTab === 'report' ? 'font-bold' : ''}>Report</button>
           <button onClick={() => setActiveTab('map')} className={activeTab === 'map' ? 'font-bold' : ''}>Map Data</button>
+          <button onClick={() => setActiveTab('reports')} className={activeTab === 'reports' ? 'font-bold' : ''}>Attack Reports</button>
         </div>
         <button onClick={loadMapData} className="bg-green-500 text-white px-2 py-1">
           {loadingMap ? 'Loading...' : 'Load Map Data'}
@@ -148,17 +279,6 @@ export default function Home() {
             <input name="reporter" placeholder="Reporter name (optional)" className="border p-2 w-full" value={form.reporter} onChange={handleChange} />
             <button type="submit" className="bg-blue-500 text-white px-4 py-2">Submit</button>
           </form>
-          {result && (
-            <div className="mt-4 border p-2">
-              <h2 className="font-bold">Report Saved</h2>
-              <p>Distance: {result.distance.toFixed(2)}</p>
-              <ul className="list-disc ml-4">
-                {result.times.map(t => (
-                  <li key={t.name}>{t.name}: {t.time}</li>
-                ))}
-              </ul>
-            </div>
-          )}
         </>
       )}
       {activeTab === 'map' && (
@@ -186,6 +306,89 @@ export default function Home() {
               </tbody>
             </table>
           </div>
+        </div>
+      )}
+      {activeTab === 'reports' && (
+        <div>
+          {reports.length === 0 ? (
+            <p>No reports yet.</p>
+          ) : (
+            <div className="overflow-auto max-h-96 border">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr>
+                    <th className="px-2 py-1 border">Defender</th>
+                    <th className="px-2 py-1 border">Attacker</th>
+                    <th className="px-2 py-1 border">Landing</th>
+                    <th className="px-2 py-1 border">Distance</th>
+                    <th className="px-2 py-1 border">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {reports.map(r => (
+                    <>
+                      <tr key={r.id}>
+                        <td className="border px-2 py-1">{r.defender}</td>
+                        <td className="border px-2 py-1">{r.attacker}</td>
+                        <td className="border px-2 py-1">{new Date(r.landing).toLocaleString('en-US', { timeZone: 'Asia/Bangkok' })}</td>
+                        <td className="border px-2 py-1">{r.distance.toFixed(2)}</td>
+                        <td className="border px-2 py-1"><button className="underline text-blue-600" onClick={() => handleFindDefense(r)}>Find Defense</button></td>
+                      </tr>
+                      <tr>
+                        <td colSpan="5">
+                          <table className="min-w-full text-xs mt-1">
+                            <thead>
+                              <tr>
+                                <th className="px-2 py-1 border">Unit</th>
+                                <th className="px-2 py-1 border">Time</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {r.times.map(t => (
+                                <tr key={t.name}>
+                                  <td className="border px-2 py-1">{t.name}</td>
+                                  <td className="border px-2 py-1">{t.time}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                          {defenseResults[r.id] && (
+                            <div className="mt-2">
+                              <p className="mb-1">Villages in alliance {defenseResults[r.id].alliance} that can arrive in time: {defenseResults[r.id].villages.length}</p>
+                              <div className="overflow-auto max-h-48 border">
+                                <table className="min-w-full text-xs">
+                                  <thead>
+                                    <tr>
+                                      <th className="px-2 py-1 border">Village</th>
+                                      <th className="px-2 py-1 border">Player</th>
+                                      <th className="px-2 py-1 border">Coords</th>
+                                      <th className="px-2 py-1 border">Unit</th>
+                                      <th className="px-2 py-1 border">Travel Time</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                    {defenseResults[r.id].villages.map((v, idx) => (
+                                      <tr key={idx}>
+                                        <td className="border px-2 py-1">{v.villageName}</td>
+                                        <td className="border px-2 py-1">{v.playerName}</td>
+                                        <td className="border px-2 py-1">({v.x}|{v.y})</td>
+                                        <td className="border px-2 py-1">{v.unit}</td>
+                                        <td className="border px-2 py-1">{v.time}</td>
+                                      </tr>
+                                    ))}
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    </>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- create `/api/reports` to list saved attack reports
- show a new **Attack Reports** tab listing all reports
- fetch stored reports when opening the tab
- add **Find Defense** button to compute alliance villages that can arrive in time
- keep timezone logic Bangkok-aware

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fb71fade8832fb81597db3cbbb7ec