### PR TITLE
Add result tab with defender ally villages arriving on time

### DIFF
--- a/pages/api/report.js
+++ b/pages/api/report.js
@@ -2,31 +2,46 @@ import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
+function parseBangkokDate(str) {
+  return new Date(`${str}+07:00`)
+}
+
 export default async function handler(req, res) {
-  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
-  const { defender, attacker, landing, firstSeen, tribe, reporter } = req.body
-  try {
-    const d1 = parseCoords(defender)
-    const d2 = parseCoords(attacker)
-    const distance = travianDistance(d1, d2)
-    const report = await prisma.attackReport.create({
-      data: {
-        defenderCoords: defender,
-        attackerCoords: attacker,
-        landingTime: new Date(landing),
-        firstSeenTime: new Date(firstSeen),
-        tribe,
-        reporter,
-      },
-    })
-    const times = troopSpeeds[tribe].map(t => ({
-      name: t.name,
-      time: formatTime(distance / t.speed),
-    }))
-    res.json({ id: report.id, distance, times })
-  } catch (e) {
-    console.error(e)
-    res.status(500).json({ error: 'Failed to save report' })
+  if (req.method === 'POST') {
+    const { defender, attacker, landing, firstSeen, tribe, reporter } = req.body
+    try {
+      const d1 = parseCoords(defender)
+      const d2 = parseCoords(attacker)
+      const distance = travianDistance(d1, d2)
+      const report = await prisma.attackReport.create({
+        data: {
+          defenderCoords: defender,
+          attackerCoords: attacker,
+          landingTime: parseBangkokDate(landing),
+          firstSeenTime: parseBangkokDate(firstSeen),
+          tribe,
+          reporter,
+        },
+      })
+      const times = troopSpeeds[tribe].map(t => ({
+        name: t.name,
+        time: formatTime(distance / t.speed),
+      }))
+      res.json({ id: report.id, distance, times })
+    } catch (e) {
+      console.error(e)
+      res.status(500).json({ error: 'Failed to save report' })
+    }
+  } else if (req.method === 'GET') {
+    try {
+      const reports = await prisma.attackReport.findMany({ orderBy: { createdAt: 'desc' } })
+      res.json({ reports })
+    } catch (e) {
+      console.error(e)
+      res.status(500).json({ error: 'Failed to load reports' })
+    }
+  } else {
+    res.status(405).json({ error: 'Method not allowed' })
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -58,6 +58,43 @@ function formatTime(hours) {
   return `${h}h ${m}m`
 }
 
+
+function parseBangkokDate(str) {
+  // treat the given local datetime string as being in the Asia/Bangkok timezone
+  return new Date(`${str}+07:00`)
+}
+
+function gatherEligibleVillages(mapData, defenderCoords, landing) {
+  const defVillage = mapData.find(v => v.x === defenderCoords.x && v.y === defenderCoords.y)
+  if (!defVillage) return { alliance: '', villages: [] }
+  const alliance = defVillage.alliance
+  const selectedUnits = ['Spearman', 'Paladin', 'Praetorian', 'Equites Caesaris', 'Phalanx', 'Druidrider']
+  const speedLookup = {}
+  Object.values(troopSpeeds).flat().forEach(t => {
+    speedLookup[t.name] = t.speed
+  })
+  // use current time in Thailand regardless of the user's timezone
+  const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Bangkok' }))
+  const landingTime = typeof landing === 'string' ? parseBangkokDate(landing) : new Date(landing)
+  const villages = []
+  mapData.forEach(v => {
+    if (v.alliance !== alliance) return
+    const dist = travianDistance(defenderCoords, { x: v.x, y: v.y })
+    let best = null
+    selectedUnits.forEach(u => {
+      const hours = dist / speedLookup[u]
+      const arrive = now.getTime() + hours * 3600 * 1000
+      if (arrive <= landingTime.getTime()) {
+        if (!best || hours < best.hours) best = { unit: u, hours }
+      }
+    })
+    if (best) {
+      villages.push({ ...v, unit: best.unit, time: formatTime(best.hours) })
+    }
+  })
+  return { alliance, villages }
+}
+
 export default function Home() {
   const [activeTab, setActiveTab] = useState('report')
   const [form, setForm] = useState({
@@ -68,11 +105,14 @@ export default function Home() {
     tribe: 'Teuton',
     reporter: '',
   })
-  const [result, setResult] = useState(null)
+  const [reports, setReports] = useState([])
   const [mapData, setMapData] = useState([])
   const [loadingMap, setLoadingMap] = useState(false)
   const [attackerVillage, setAttackerVillage] = useState('')
   const [defenderVillage, setDefenderVillage] = useState('')
+  const [defenderAlliance, setDefenderAlliance] = useState('')
+  const [eligibleVillages, setEligibleVillages] = useState([])
+  const [selectedReportId, setSelectedReportId] = useState(null)
 
   const handleChange = e => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -80,17 +120,22 @@ export default function Home() {
       const coords = parseCoordsInput(e.target.value)
       const village = coords ? mapData.find(v => v.x === coords.x && v.y === coords.y) : null
       if (e.target.name === 'attacker') setAttackerVillage(village ? village.villageName : '')
-      if (e.target.name === 'defender') setDefenderVillage(village ? village.villageName : '')
+      if (e.target.name === 'defender') {
+        setDefenderVillage(village ? village.villageName : '')
+        setDefenderAlliance(village ? village.alliance : '')
+      }
     }
   }
 
   const loadMapData = async () => {
+    if (mapData.length) return mapData
     setLoadingMap(true)
     try {
       const res = await fetch('/api/map')
       const data = await res.json()
       if (res.ok) {
         setMapData(data.villages)
+        return data.villages
       } else {
         alert(data.error || 'Failed to load map data')
       }
@@ -98,6 +143,21 @@ export default function Home() {
       alert('Failed to load map data')
     } finally {
       setLoadingMap(false)
+    }
+    return []
+  }
+
+  const loadReports = async () => {
+    try {
+      const res = await fetch('/api/report')
+      const data = await res.json()
+      if (res.ok) {
+        setReports(data.reports)
+      } else {
+        alert(data.error || 'Failed to load reports')
+      }
+    } catch (e) {
+      alert('Failed to load reports')
     }
   }
 
@@ -110,10 +170,21 @@ export default function Home() {
     })
     const data = await res.json()
     if (res.ok) {
-      setResult(data)
+      await loadReports()
+      setActiveTab('reports')
     } else {
       alert(data.error || 'Error')
     }
+  }
+
+  const handleFindDefense = async report => {
+    let currentMap = await loadMapData()
+    if (!currentMap.length) return
+    const coords = parseCoordsInput(report.defenderCoords)
+    const { alliance, villages } = gatherEligibleVillages(currentMap, coords, report.landingTime)
+    setDefenderAlliance(alliance)
+    setEligibleVillages(villages)
+    setSelectedReportId(report.id)
   }
 
   return (
@@ -122,6 +193,7 @@ export default function Home() {
         <div className="space-x-2">
           <button onClick={() => setActiveTab('report')} className={activeTab === 'report' ? 'font-bold' : ''}>Report</button>
           <button onClick={() => setActiveTab('map')} className={activeTab === 'map' ? 'font-bold' : ''}>Map Data</button>
+          <button onClick={() => { setActiveTab('reports'); loadReports() }} className={activeTab === 'reports' ? 'font-bold' : ''}>Attack Reports</button>
         </div>
         <button onClick={loadMapData} className="bg-green-500 text-white px-2 py-1">
           {loadingMap ? 'Loading...' : 'Load Map Data'}
@@ -148,17 +220,6 @@ export default function Home() {
             <input name="reporter" placeholder="Reporter name (optional)" className="border p-2 w-full" value={form.reporter} onChange={handleChange} />
             <button type="submit" className="bg-blue-500 text-white px-4 py-2">Submit</button>
           </form>
-          {result && (
-            <div className="mt-4 border p-2">
-              <h2 className="font-bold">Report Saved</h2>
-              <p>Distance: {result.distance.toFixed(2)}</p>
-              <ul className="list-disc ml-4">
-                {result.times.map(t => (
-                  <li key={t.name}>{t.name}: {t.time}</li>
-                ))}
-              </ul>
-            </div>
-          )}
         </>
       )}
       {activeTab === 'map' && (
@@ -186,6 +247,69 @@ export default function Home() {
               </tbody>
             </table>
           </div>
+        </div>
+      )}
+      {activeTab === 'reports' && (
+        <div>
+          <p className="mb-2">Total reports: {reports.length}</p>
+          <div className="overflow-auto max-h-96 border mb-4">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1 border">Defender</th>
+                  <th className="px-2 py-1 border">Attacker</th>
+                  <th className="px-2 py-1 border">Landing</th>
+                  <th className="px-2 py-1 border">Tribe</th>
+                  <th className="px-2 py-1 border">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reports.map(r => (
+                  <tr key={r.id}>
+                    <td className="border px-2 py-1">{r.defenderCoords}</td>
+                    <td className="border px-2 py-1">{r.attackerCoords}</td>
+                    <td className="border px-2 py-1">{new Date(r.landingTime).toLocaleString('en-US', { timeZone: 'Asia/Bangkok' })}</td>
+                    <td className="border px-2 py-1">{r.tribe}</td>
+                    <td className="border px-2 py-1">
+                      <button className="underline text-blue-500" onClick={() => handleFindDefense(r)}>Find Defense</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {selectedReportId && eligibleVillages.length > 0 && (
+            <div>
+              <p className="mb-2">Villages in alliance {defenderAlliance} that can arrive in time: {eligibleVillages.length}</p>
+              <div className="overflow-auto max-h-96 border">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr>
+                      <th className="px-2 py-1 border">Village</th>
+                      <th className="px-2 py-1 border">Player</th>
+                      <th className="px-2 py-1 border">Coords</th>
+                      <th className="px-2 py-1 border">Unit</th>
+                      <th className="px-2 py-1 border">Travel Time</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {eligibleVillages.map((v, idx) => (
+                      <tr key={idx}>
+                        <td className="border px-2 py-1">{v.villageName}</td>
+                        <td className="border px-2 py-1">{v.playerName}</td>
+                        <td className="border px-2 py-1">({v.x}|{v.y})</td>
+                        <td className="border px-2 py-1">{v.unit}</td>
+                        <td className="border px-2 py-1">{v.time}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+          {selectedReportId && eligibleVillages.length === 0 && (
+            <p>No villages from alliance {defenderAlliance} can arrive in time.</p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow GET on `report` API to fetch existing reports
- return to new `Attack Reports` tab after submitting
- view saved attacks and use **Find Defense** button to list ally villages that can arrive before landing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fb71fade8832fb81597db3cbbb7ec